### PR TITLE
Removing "sessionId=" from socket url query params

### DIFF
--- a/tss-client-android/src/main/java/com/web3auth/tss_client_android/client/TSSSocket.java
+++ b/tss-client-android/src/main/java/com/web3auth/tss_client_android/client/TSSSocket.java
@@ -22,7 +22,7 @@ public class TSSSocket {
         try {
             IO.Options options;
             boolean local_servers = System.getProperty("LOCAL_SERVERS") != null;
-            String query = "sessionId=" + session.split(Delimiters.Delimiter4)[1];
+            String query = session.split(Delimiters.Delimiter4)[1];
             if (local_servers) {
                 options = IO.Options.builder()
                         .setQuery(query)


### PR DESCRIPTION
Removing "sessionId=" from socket url query params